### PR TITLE
fix: spoilers in callouts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,7 @@ export default class SpoilersPlugin extends Plugin {
 			});
 
 			// Button toolbar
-			const toolbar = el.createEl("div", {
+			const toolbar = container.createEl("div", {
 				cls: "spoiler-toolbar",
 			});
 
@@ -78,7 +78,8 @@ export default class SpoilersPlugin extends Plugin {
 				.setIcon("eye")
 				.setClass("spoiler-button")
 				.setTooltip("Click to reveal")
-				.onClick(function () {
+				.onClick(function (event) {
+					event.stopPropagation();
 					spoilerCover.toggleAttribute("data-visible");
 				});
 
@@ -87,7 +88,8 @@ export default class SpoilersPlugin extends Plugin {
 				.setIcon("copy")
 				.setClass("spoiler-button")
 				.setTooltip("Copy to clipboard")
-				.onClick(function () {
+				.onClick(function (event) {
+					event.stopPropagation();
 					navigator.clipboard.writeText(copyText);
 				});
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,21 +23,13 @@
 	opacity: 1;
 }
 
+.callout-content .spoiler__cover {
+	background-color: black;
+}
+
 .spoiler__cover[data-visible] {
 	opacity: 0;
 	pointer-events: none;
-}
-
-@media print {
-	.spoiler__cover {
-		background-color: rgba(0, 0, 0, 1);
-		color: white;
-	}
-
-	.spoiler__cover--export__reveal {
-		opacity: 0;
-		pointer-events: none;
-	}
 }
 
 .spoiler-toolbar {
@@ -65,4 +57,20 @@
 
 .spoiler-table-cell:hover .spoiler-table-copy {
 	opacity: 1;
+}
+
+@media print {
+	.spoiler__cover {
+		background-color: rgba(0, 0, 0, 1);
+		color: white;
+	}
+
+	.spoiler__cover--export__reveal {
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	.spoiler-toolbar {
+		display: none;
+	}
 }


### PR DESCRIPTION
## Description

Fixes spoilers placed into markdown callouts

## Changes
- Moved the toolbar into the container so it renders properly in callouts
- Stop click event propagation so click events on the view and copy buttons don't trigger editing of callouts
- Hide toolbar when printing (Exporting to PDF)

## Related Issues
- Closes #1 