### PR TITLE
Fix: callouts visible through spoiler

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -79,6 +79,7 @@ export default class SpoilersPlugin extends Plugin {
 				.onClick(function (event) {
 					event.stopPropagation();
 					spoilerCover.toggleAttribute("data-visible");
+					container.toggleAttribute("data-spoiler-visible");
 				});
 
 			// Create copy button

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,6 +23,10 @@
 	opacity: 1;
 }
 
+.spoiler:not([data-spoiler-visible]) > * {
+	mix-blend-mode: normal;
+}
+
 .callout-content .spoiler__cover {
 	background-color: black;
 }


### PR DESCRIPTION
## Description

Fixes a bug where callouts present in markdown spoilers are visible through the blurring. The callout element has a special `mix-blend-mode` of `lighten` which causes the blur effect to not be applied

## Changes

- Always apply the `mix-blend-mode: normal;` styling to elements within the spoiler when the spoiler is not in the visible mode

## Related Issues

- Closes #5 